### PR TITLE
Update the logic with applicationRole arn usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ const ssoAdminClient = new SSOAdminClient({
 });
 ```
 
+Please refer to the [TIP Plugin documentation](https://docs.aws.amazon.com/sdkref/latest/guide/access-tip.html) for input parameters details.
+
 ## Install from source
 
 The plugin has been published to NPM and can be installed as described above. If you want to play with the latest version, you can build from source as follows.

--- a/e2e/integration.spec.ts
+++ b/e2e/integration.spec.ts
@@ -12,6 +12,7 @@ import { TrustedIdentityPropagationExtension } from '../src/trustedIdentityPropa
 
 const env = getIntegrationTestEnvironment();
 const ssoOidcClient = new SSOOIDCClient({ region: env.Region });
+const stsClient = new STSClient({ region: env.Region });
 
 describe.concurrent('integration tests', () => {
     it('returns credentials when given a valid web token', async ({ expect }) => {
@@ -25,6 +26,7 @@ describe.concurrent('integration tests', () => {
                     accessRoleArn: env.AccessRoleArn,
                     applicationArn: env.IdcApplicationArn,
                     ssoOidcClient,
+                    stsClient,
                 }),
             ],
         });
@@ -49,6 +51,7 @@ describe.concurrent('integration tests', () => {
                     accessRoleArn: env.AccessRoleArn,
                     applicationArn: env.IdcApplicationArn,
                     ssoOidcClient,
+                    stsClient,
                 }),
             ],
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk-extension/trusted-identity-propagation",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "AWS credential provider that sources credentials that obtains identity-aware credentials for trusted identity propagation",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/src/fromTrustedTokenIssuer.spec.ts
+++ b/src/fromTrustedTokenIssuer.spec.ts
@@ -1,5 +1,5 @@
 import { SSOOIDCClient } from '@aws-sdk/client-sso-oidc';
-import { AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import type { AwsIdentityProperties } from '@aws-sdk/types';
 import { faker } from '@faker-js/faker';
 import { type MockInstance, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,7 +13,7 @@ import {
     lowercaseSdkCredential,
 } from '../tests/helpers';
 import {
-    mockResolveSsoOidcClient,
+    mockRetrieveCredentialsWithWebIdentity,
     mockRetrieveSsoOidcTokens,
     mockSsoOidcClientOutputs,
     mockStsClientOutputs,
@@ -46,18 +46,23 @@ const ssoOidcClient = new SSOOIDCClient({
     credentials: generateSdkCredentials('lowercase'),
 });
 
+const stsClient = new STSClient({
+    region,
+    credentials: generateSdkCredentials('lowercase'),
+});
+
 describe('fromTrustedTokenIssuer', () => {
     const bootstrapCredentials = generateSdkCredentials('uppercase');
     const identityContext = faker.string.alphanumeric(100);
     const oidcTokens = generateOidcTokens(identityContext);
     const identityEnhancedCredentials = generateSdkCredentials('uppercase');
 
-    let resolveSsoOidcClient: MockInstance;
+    let retrieveCredentialsWithWebIdentity: MockInstance;
 
     beforeEach(() => {
         vi.clearAllMocks();
 
-        resolveSsoOidcClient = mockResolveSsoOidcClient();
+        retrieveCredentialsWithWebIdentity = mockRetrieveCredentialsWithWebIdentity();
 
         mockStsClientOutputs({
             AssumeRoleWithWebIdentityCommand: () => ({ Credentials: bootstrapCredentials }),
@@ -85,6 +90,58 @@ describe('fromTrustedTokenIssuer', () => {
         });
     });
 
+    it('throws error if both applicationRoleArn, ssoOidcClient and ssoOidcClient is not provided', async () => {
+        const config: FromTrustedTokenIssuerProps = {
+            webTokenProvider,
+            accessRoleArn,
+            applicationArn,
+            stsClient,
+        };
+
+        await expect(() => fromTrustedTokenIssuer(config)({ callerClientConfig })).rejects.toThrow(
+            'Either both of ssoOidcClient and stsClient OR the application role must be provided.'
+        );
+    });
+
+    it('throws error if both applicationRoleArn and ssoOidcClient is not provided', async () => {
+        const config: FromTrustedTokenIssuerProps = {
+            webTokenProvider,
+            accessRoleArn,
+            applicationArn,
+            stsClient,
+        };
+
+        await expect(() => fromTrustedTokenIssuer(config)({ callerClientConfig })).rejects.toThrow(
+            'Either both of ssoOidcClient and stsClient OR the application role must be provided.'
+        );
+    });
+
+    it('throws error if both applicationRoleArn and stsClient is not provided', async () => {
+        const config: FromTrustedTokenIssuerProps = {
+            webTokenProvider,
+            accessRoleArn,
+            applicationArn,
+            ssoOidcClient,
+        };
+
+        await expect(() => fromTrustedTokenIssuer(config)({ callerClientConfig })).rejects.toThrow(
+            'Either both of ssoOidcClient and stsClient OR the application role must be provided.'
+        );
+    });
+
+    it('throws error if both applicationRoleArn and accessRoleArn are same', async () => {
+        const config: FromTrustedTokenIssuerProps = {
+            webTokenProvider,
+            applicationRoleArn: accessRoleArn,
+            accessRoleArn,
+            applicationArn,
+        };
+
+        await expect(() => fromTrustedTokenIssuer(config)({ callerClientConfig })).rejects.toThrow(
+            'Access Role and Application Role can not be same as it leads to self role assumption.'
+        );
+    });
+
     it('uses region from callerClientConfig', async () => {
         await fromTrustedTokenIssuer({
             webTokenProvider,
@@ -93,7 +150,7 @@ describe('fromTrustedTokenIssuer', () => {
             applicationArn,
         })({ callerClientConfig });
 
-        expect(resolveSsoOidcClient).toHaveBeenCalledWith(expect.objectContaining({ region }));
+        expect(retrieveCredentialsWithWebIdentity).toHaveBeenCalledWith(expect.objectContaining({ region }));
     });
 
     it('throws error if region cannot be determined', async () => {
@@ -107,7 +164,7 @@ describe('fromTrustedTokenIssuer', () => {
         ).rejects.toThrow('Region not found');
     });
 
-    it('calls "resolveSsoOidcClient" if "ssoOidcClient" is not provided', async () => {
+    it('calls "retrieveCredentialsWithWebIdentity" if "ssoOidcClient" is not provided', async () => {
         await fromTrustedTokenIssuer({
             webTokenProvider,
             applicationRoleArn,
@@ -115,7 +172,7 @@ describe('fromTrustedTokenIssuer', () => {
             applicationArn,
         })({ callerClientConfig });
 
-        expect(resolveSsoOidcClient).toHaveBeenCalledWith(
+        expect(retrieveCredentialsWithWebIdentity).toHaveBeenCalledWith(
             expect.objectContaining({
                 webToken,
                 applicationRoleArn,
@@ -138,6 +195,7 @@ describe('fromTrustedTokenIssuer', () => {
 
         await fromTrustedTokenIssuer({
             webTokenProvider,
+            applicationRoleArn,
             accessRoleArn,
             applicationArn,
         })({ callerClientConfig });
@@ -151,6 +209,7 @@ describe('fromTrustedTokenIssuer', () => {
             accessRoleArn,
             applicationArn,
             ssoOidcClient,
+            stsClient,
         })({ callerClientConfig });
 
         expect(webTokenProvider).toHaveBeenCalledOnce();
@@ -162,6 +221,7 @@ describe('fromTrustedTokenIssuer', () => {
             accessRoleArn,
             applicationArn,
             ssoOidcClient,
+            stsClient,
         });
 
         /**
@@ -183,6 +243,7 @@ describe('fromTrustedTokenIssuer', () => {
 
         await fromTrustedTokenIssuer({
             webTokenProvider,
+            applicationRoleArn,
             accessRoleArn,
             applicationArn,
         })({ callerClientConfig });
@@ -203,6 +264,7 @@ describe('fromTrustedTokenIssuer', () => {
 
         const provider = fromTrustedTokenIssuer({
             webTokenProvider,
+            applicationRoleArn,
             accessRoleArn,
             applicationArn,
         });
@@ -231,6 +293,7 @@ describe('fromTrustedTokenIssuer', () => {
     it('calls "AssumeRole" with the "accessRoleArn" parameter and the user identity context assertion', async () => {
         await fromTrustedTokenIssuer({
             webTokenProvider,
+            applicationRoleArn,
             accessRoleArn,
             applicationArn,
         })({ callerClientConfig });
@@ -252,6 +315,7 @@ describe('fromTrustedTokenIssuer', () => {
     it('returns identity-enhanced session with expiration from the "AssumeRole" response', async () => {
         const credentials = await fromTrustedTokenIssuer({
             webTokenProvider,
+            applicationRoleArn,
             accessRoleArn,
             applicationArn,
         })({ callerClientConfig });

--- a/src/fromTrustedTokenIssuer.ts
+++ b/src/fromTrustedTokenIssuer.ts
@@ -1,10 +1,12 @@
-import type { SSOOIDCClient } from '@aws-sdk/client-sso-oidc';
+import { SSOOIDCClient } from '@aws-sdk/client-sso-oidc';
 import { STSClient } from '@aws-sdk/client-sts';
-import { AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { AssumeRoleCommand, Credentials } from '@aws-sdk/client-sts';
 import type {
     CredentialProviderOptions,
     RuntimeConfigAwsCredentialIdentityProvider,
     UserAgentPair,
+    AwsCredentialIdentity,
+    AwsCredentialIdentityProvider,
 } from '@aws-sdk/types';
 import { CredentialsProviderError } from '@smithy/property-provider';
 
@@ -16,7 +18,7 @@ import {
     PLUGIN_METRIC_PREFIX,
 } from './constants';
 import { getIdentityEnhancedSessionName } from './helpers';
-import { resolveSsoOidcClient } from './resolveSsoOidcClient';
+import { retrieveCredentialsWithWebIdentity } from './retrieveCredentialsWithWebIdentity';
 import { retrieveSsoOidcTokens } from './retrieveSsoOidcTokens';
 
 export interface FromTrustedTokenIssuerProps extends CredentialProviderOptions {
@@ -86,24 +88,53 @@ export const fromTrustedTokenIssuer = (
             throw new CredentialsProviderError('Region not found', { logger, tryNextLink: false });
         }
 
+        let ssoOidcClient = init.ssoOidcClient;
+        let stsClient = init.stsClient;
+        let webToken: string | undefined = undefined;
+
+        if (!ssoOidcClient || !stsClient) {
+            if (!applicationRoleArn) {
+                throw new CredentialsProviderError('Either both of ssoOidcClient and stsClient OR the application role must be provided.',
+                                                    { logger, tryNextLink: false });
+            }
+
+            if (accessRoleArn === applicationRoleArn) {
+                throw new CredentialsProviderError('Access Role and Application Role can not be same as it leads to self role assumption.',
+                            { logger, tryNextLink: false });
+            }
+
+            webToken = await webTokenProvider();
+            const webIdentityCredentials: AwsCredentialIdentity = await retrieveCredentialsWithWebIdentity({
+                webToken,
+                applicationRoleArn: applicationRoleArn,
+                applicationArn,
+                region,
+                logger,
+            });
+
+            if (!ssoOidcClient) {
+                ssoOidcClient = new SSOOIDCClient({
+                    credentials: webIdentityCredentials,
+                    region,
+                    logger,
+                });
+            }
+
+            if (!stsClient) {
+                stsClient = new STSClient({
+                    credentials: webIdentityCredentials,
+                    region,
+                    logger,
+                });
+            }
+        }
+
         const pluginUserAgentSegment: UserAgentPair = [
             PLUGIN_METRIC_PREFIX,
             `${PLUGIN_METRIC_LABEL}#${PACKAGE_VERSION}`,
         ];
 
-        let webToken: string | undefined = undefined;
-        let ssoOidcClient = init.ssoOidcClient;
 
-        if (!ssoOidcClient) {
-            webToken = await webTokenProvider();
-            ssoOidcClient = await resolveSsoOidcClient({
-                webToken,
-                applicationRoleArn: applicationRoleArn || accessRoleArn,
-                applicationArn,
-                region,
-                logger,
-            });
-        }
         ssoOidcClient.config.customUserAgent ??= [];
         ssoOidcClient.config.customUserAgent.push(pluginUserAgentSegment);
 
@@ -119,13 +150,6 @@ export const fromTrustedTokenIssuer = (
 
         ssoOidcRefreshToken = idcTokens.refreshToken;
 
-        const stsClient =
-            init.stsClient ||
-            new STSClient({
-                credentials: ssoOidcClient.config.credentials,
-                region,
-                logger,
-            });
         stsClient.config.customUserAgent ??= [];
         stsClient.config.customUserAgent.push(pluginUserAgentSegment);
 

--- a/src/retrieveCredentialsWithWebIdentity.spec.ts
+++ b/src/retrieveCredentialsWithWebIdentity.spec.ts
@@ -9,9 +9,8 @@ import {
     lowercaseSdkCredential,
 } from '../tests/helpers';
 import { mockStsClientOutputs } from '../tests/mocks';
-import { resolveSsoOidcClient } from './resolveSsoOidcClient';
+import { retrieveCredentialsWithWebIdentity } from './retrieveCredentialsWithWebIdentity';
 
-vi.mock('@aws-sdk/client-sso-oidc', (importOriginal) => importOriginal());
 vi.mock('@aws-sdk/client-sts', async (importOriginal) => ({
     ...(await importOriginal()),
     AssumeRoleWithWebIdentityCommand: vi.fn().mockName('AssumeRoleWithWebIdentityCommand'),
@@ -22,7 +21,7 @@ const applicationRoleArn = generateRoleArn();
 const applicationArn = generateApplicationArn();
 const region = 'us-east-1';
 
-describe('resolveSsoOidcClient', () => {
+describe('retrieveCredentialsWithWebIdentity', () => {
     const bootstrapSdkCredentials = generateSdkCredentials('uppercase');
     const credentials = lowercaseSdkCredential(bootstrapSdkCredentials);
 
@@ -34,22 +33,21 @@ describe('resolveSsoOidcClient', () => {
         });
     });
 
-    it('returns new SSOOIDCClient using bootstrapped session', async () => {
-        const result = await resolveSsoOidcClient({
+    it('returns new session using the web identity token', async () => {
+        const result = await retrieveCredentialsWithWebIdentity({
             webToken,
             applicationRoleArn,
             applicationArn,
             region,
         });
 
-        expect(await result.config.credentials()).toEqual(
+        expect(await result).toEqual(
             expect.objectContaining({
                 accessKeyId: credentials.accessKeyId,
                 secretAccessKey: credentials.secretAccessKey,
                 sessionToken: credentials.sessionToken,
             })
         );
-        expect(await result.config.region()).toEqual(region);
         expect(AssumeRoleWithWebIdentityCommand).toHaveBeenCalledWith(
             expect.objectContaining({
                 RoleArn: applicationRoleArn,

--- a/src/retrieveCredentialsWithWebIdentity.ts
+++ b/src/retrieveCredentialsWithWebIdentity.ts
@@ -1,23 +1,23 @@
 import { SSOOIDCClient } from '@aws-sdk/client-sso-oidc';
 import { AssumeRoleWithWebIdentityCommand, STSClient } from '@aws-sdk/client-sts';
-import type { CredentialProviderOptions } from '@aws-sdk/types';
+import type { AwsCredentialIdentity, CredentialProviderOptions } from '@aws-sdk/types';
 import { CredentialsProviderError } from '@smithy/property-provider';
 import { getBootstrapSessionName } from './helpers';
 
-export interface ResolveSsoOidcClientParameters {
+export interface RetrieveCredentialsWithWebIdentityParameters {
     webToken: string;
     applicationRoleArn: string;
     applicationArn: string;
     region: string;
 }
 
-export const resolveSsoOidcClient = async ({
+export const retrieveCredentialsWithWebIdentity = async ({
     webToken,
     applicationRoleArn,
     applicationArn,
     region,
     logger,
-}: ResolveSsoOidcClientParameters & CredentialProviderOptions): Promise<SSOOIDCClient> => {
+}: RetrieveCredentialsWithWebIdentityParameters & CredentialProviderOptions): Promise<AwsCredentialIdentity> => {
     const stsClient = new STSClient({ region, logger });
     const { Credentials: iamTokens } = await stsClient.send(
         new AssumeRoleWithWebIdentityCommand({
@@ -34,13 +34,11 @@ export const resolveSsoOidcClient = async ({
         });
     }
 
-    return new SSOOIDCClient({
-        credentials: {
-            accessKeyId: iamTokens.AccessKeyId,
-            secretAccessKey: iamTokens.SecretAccessKey,
-            sessionToken: iamTokens.SessionToken,
-        },
-        region,
-        logger,
-    });
+    const staticCredentials: AwsCredentialIdentity = {
+      accessKeyId: iamTokens.AccessKeyId,
+      secretAccessKey: iamTokens.SecretAccessKey,
+      sessionToken: iamTokens.SessionToken,
+    };
+
+    return staticCredentials;
 };

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -1,17 +1,21 @@
 import { CreateTokenWithIAMCommandOutput, CreateTokenWithIAMResponse, SSOOIDCClient } from '@aws-sdk/client-sso-oidc';
-import { AssumeRoleCommandOutput, AssumeRoleWithWebIdentityCommandOutput, STSClient } from '@aws-sdk/client-sts';
+import { AssumeRoleCommandOutput, AssumeRoleWithWebIdentityCommandOutput, STSClient, Credentials } from '@aws-sdk/client-sts';
+import type { AwsCredentialIdentity } from '@aws-sdk/types';
 import { vi } from 'vitest';
 
 import * as fromTrustedTokenIssuer from '../src/fromTrustedTokenIssuer';
 import * as resolveSsoOidcClient from '../src/resolveSsoOidcClient';
+import * as retrieveCredentialsWithWebIdentity from '../src/retrieveCredentialsWithWebIdentity';
 import * as retrieveSsoOidcTokens from '../src/retrieveSsoOidcTokens';
 
 const testRegion = 'us-east-1';
 
-export const mockResolveSsoOidcClient = () => {
+export const mockRetrieveCredentialsWithWebIdentity = () => {
     return vi
-        .spyOn(resolveSsoOidcClient, 'resolveSsoOidcClient')
-        .mockResolvedValue(new SSOOIDCClient({ region: testRegion }));
+        .spyOn(retrieveCredentialsWithWebIdentity, 'retrieveCredentialsWithWebIdentity')
+        .mockResolvedValue({ accessKeyId: 'mockAccessKeyId',
+                             secretAccessKey: 'mockSecretAccessKey',
+                             sessionToken: 'mockSessionToken' });
 };
 
 export const mockRetrieveSsoOidcTokens = (tokens: CreateTokenWithIAMResponse) => {


### PR DESCRIPTION
**Description of changes:**
Update the applicationRoleArn parameter requirements and create a new major version with the following changes:
Make either `ssoOidcClient` or `applicationRoleArn` required, the provided parameter reflects the client's intention as to whether they want to use existing credentials (e.g. default credentials) or use the applicationRole for `sso-oauth:CreateTokenWithIAM` and `sts:AssumeRole` permissions.
- If `ssoOidcClient` is provided, use the credentials on it for `sso & sts` access
- otherwise,  make `applicationRoleArn` mandatory and make sure it's not same as `accessRole` in order to avoid self-role assumption
- 
**Testing**
- Unit Tests
- Manual tests with Idc test application setup with S3AccessGrants